### PR TITLE
Volume's attached server may be null

### DIFF
--- a/lib/src/main/kotlin/tech/sco/hetznerkloud/model/Volume.kt
+++ b/lib/src/main/kotlin/tech/sco/hetznerkloud/model/Volume.kt
@@ -21,7 +21,7 @@ data class Volume(
     val location: Location,
     val name: String,
     val protection: Protection,
-    val server: Server.Id,
+    val server: Server.Id?,
     val size: Long,
     val status: Status,
 ) {


### PR DESCRIPTION
According to the [Hetzner API reference](https://docs.hetzner.cloud/#volumes-get-all-volumes), the server field will be set to `null` if the volume is not attached to any server.

This change makes sure that the library won't crash at runtime due to an unexpected token (in this case, `null`).