### PR TITLE
Use an environment variable for the api token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 # Ignore Gradle build output directory
 build
 
-lib/src/test/resources/token.txt
-
 .kotlin
 
 local.properties

--- a/lib/src/test/kotlin/tech/sco/hetznerkloud/IntegrationTest.kt
+++ b/lib/src/test/kotlin/tech/sco/hetznerkloud/IntegrationTest.kt
@@ -1,14 +1,14 @@
 package tech.sco.hetznerkloud
 
 import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.mpp.env
 import kotlinx.coroutines.runBlocking
-import kotlinx.io.files.Path
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 
 class IntegrationTest : AnnotationSpec() {
 
     private val cloudApiClient = CloudApiClient.of(
-        ApiToken.load(Path("src/test/resources/token.txt")),
+        ApiToken(env("API_TEST_TOKEN") ?: error("Missing environment variable API_TEST_TOKEN.")),
     )
 
     @Test fun itGetsServers() {


### PR DESCRIPTION
Instead of using a text file with the Hetzner API token as it's content, it is more convenient to use an environment variable for providing access to the Hetzner API.