### PR TITLE
Refactor IntegrationTest.kt to not crash on empty list responses

### DIFF
--- a/lib/src/test/kotlin/tech/sco/hetznerkloud/IntegrationTest.kt
+++ b/lib/src/test/kotlin/tech/sco/hetznerkloud/IntegrationTest.kt
@@ -16,7 +16,9 @@ class IntegrationTest : AnnotationSpec() {
             runBlocking {
                 cloudApiClient.servers.all().let {
                     println(it)
-                    cloudApiClient.servers.find(it.items.first().id)
+                    it.items.firstOrNull()?.let { item ->
+                        cloudApiClient.servers.find(item.id)
+                    }
                 }
             }
         }
@@ -38,7 +40,9 @@ class IntegrationTest : AnnotationSpec() {
             runBlocking {
                 cloudApiClient.loadBalancers.all().let {
                     println(it)
-                    cloudApiClient.loadBalancers.find(it.items.first().id)
+                    it.items.firstOrNull()?.let { item ->
+                        cloudApiClient.loadBalancers.find(item.id)
+                    }
                 }
             }
         }
@@ -60,7 +64,9 @@ class IntegrationTest : AnnotationSpec() {
             runBlocking {
                 cloudApiClient.networks.all().let {
                     println(it)
-                    cloudApiClient.networks.find(it.items.first().id)
+                    it.items.firstOrNull()?.let { item ->
+                        cloudApiClient.networks.find(item.id)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Before the change, the test cases expected the user's Hetzner Cloud account to have at least one of a server, load balancer or network to exist and to assert on. A user might not have, let's say, a load balancer. Therefore, we should only try to `find` an entity if there actually exists any.