### PR TITLE
Match file name parameter with the actual file name 

### DIFF
--- a/lib/src/test/kotlin/tech/sco/hetznerkloud/VolumeApiTest.kt
+++ b/lib/src/test/kotlin/tech/sco/hetznerkloud/VolumeApiTest.kt
@@ -285,7 +285,7 @@ class VolumeApiTest :
             should("attach a Volume to server") {
                 val attachVolumeRequest = AttachToServer(false, Server.Id(43))
 
-                jsonEncoder().encodeToString(attachVolumeRequest) shouldBeEqualToRequest "attach_a_volume_to_Server.json"
+                jsonEncoder().encodeToString(attachVolumeRequest) shouldBeEqualToRequest "attach_a_volume_to_server.json"
 
                 underTest.volumes.attachToServer(volumeId, attachVolumeRequest) shouldBe Item(
                     Action(


### PR DESCRIPTION
When running the tests on a non-Windows machine, then a test will fail due to a `FileNotFoundException`. The reason for this is that the file name is not using the correct capitilization, which on a Windows machine is ignored due to case-insensitivity.

This hotfix solves this problem.