### PR TITLE
Fix failure on server creation

### DIFF
--- a/lib/src/main/kotlin/tech/sco/hetznerkloud/request/Server.kt
+++ b/lib/src/main/kotlin/tech/sco/hetznerkloud/request/Server.kt
@@ -2,7 +2,12 @@ package tech.sco.hetznerkloud.request
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import tech.sco.hetznerkloud.model.*
+import tech.sco.hetznerkloud.model.Image
+import tech.sco.hetznerkloud.model.Iso
+import tech.sco.hetznerkloud.model.Labels
+import tech.sco.hetznerkloud.model.Network
+import tech.sco.hetznerkloud.model.PlacementGroup
+import tech.sco.hetznerkloud.model.SSHKey
 
 // TODO: check which values can be omitted and which ones can be sent as null
 @Serializable


### PR DESCRIPTION
Creating a server requires to have set either the `location` or the `datacenter` field but not both at the same time.

This refactor changes the `CreateServer` constructor such that both fields are nullable but will definitely be set by the secondary constructor. It also now includes a more precise way to set the required field by using sealed classes.

Setting an empty string on the previous revision of the constructor was not an option, as the Hetzner API requires that field to not be set in general.

This is a **breaking change** and will result to compilation errors on update and usage of the `CreateServer` class.
