### PR TITLE
make volume format nullable

### DIFF
--- a/lib/src/main/kotlin/tech/sco/hetznerkloud/model/Volume.kt
+++ b/lib/src/main/kotlin/tech/sco/hetznerkloud/model/Volume.kt
@@ -14,7 +14,7 @@ data class Volume(
     val id: Id,
     @Serializable(with = OffsetDateTimeSerializer::class)
     val created: OffsetDateTime,
-    val format: String,
+    val format: String?,
     val labels: Labels,
     @JsonNames("linux_device")
     val linuxDevice: String,


### PR DESCRIPTION
Volumes do not necessarily need to be formatted on creation, which is why the `format` property of a volume can be `null`. This is confirmed in the Hetzner API reference: https://docs.hetzner.cloud/#volumes-get-all-volumes